### PR TITLE
Removing the Install Check Patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         },
         "patches": {
             "drupal/core": {
-                "install failure": "https://raw.githubusercontent.com/stevector/drupal-9-project/master/patches/issue-1--core-install-error.patch",
                 "db version": "https://raw.githubusercontent.com/stevector/drupal-9-project/master/patches/issue-2--mariadb-version.patch"
             }
         },


### PR DESCRIPTION
Thanks to the work in https://www.drupal.org/project/drupal/issues/3120731, https://raw.githubusercontent.com/stevector/drupal-9-project/master/patches/issue-1--core-install-error.patch is no longer needed.